### PR TITLE
CHANGELOG: Fix hierarchy long option rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
   * tpm2_quote: Option `--ak-passwd` changes to `--auth-ak`
   * tpm2_pcrevent: Option `--passwd` changes to `--auth-pcr`
   * tpm2_nvwrite: Options `--authhandle` and `--handle-passwd`
-    changes to `--auth-hierarchy` and `--auth-hierarchy-value` respectively.
+    changes to `--hierarchy` and `--auth-hierarchy` respectively.
   * tpm2_nvread: Options `--authhandle` and `--handle-passwd`
-    changes to `--auth-hierarchy` and `--auth-hierarchy-value` respectively.
+    changes to `--hierarchy` and `--auth-hierarchy` respectively.
   * tpm2_nvdefine: Options `--authhandle`, `--handle-passwd` and `--index-passwd`
-    changes to `--auth-hierarchy`, `--auth-hierarchy-value` and `--auth-index`
+    changes to `--hierarchy`, `--auth-hierarchy` and `--auth-index`
     respectively.
   * tpm2_loadexternal: `-H` changes to `-a` for specifying hierarchy.
   * tpm2_load: Option `--pwdp` changes to `--auth-parent`.


### PR DESCRIPTION
Some of the long option renames in the CHANGELOG.md were not correct, fix them.
- tpm2_nvwrite
- tpm2_nvread
- tpm2_nvdefine

Should be updated together in the previous PR https://github.com/tpm2-software/tpm2-tools/pull/970